### PR TITLE
Dockerfile: preinstall msmtp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,21 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## [1.4.2-r35] · 2024-??-?? (unreleased)
-[1.4.2-r35]: /../../tree/1.4.2-r35
+## [1.4.2-r36] · 2024-03-12
+[1.4.2-r36]: /../../tree/1.4.2-r36
 
-[Diff](/../../compare/1.4.2-r35...)
+[Diff](/../../compare/1.4.2-r35...1.4.2-r36)
+
+### Added
+
+- Sending reports support via [`msmtp`]. ([#10], [#9])
 
 ### Security updated
 
 - [Debian Linux] "bookworm" 20240311 (12.5): <https://github.com/docker-library/official-images/commit/c67fd26a4cbfe0f59d8013bc1e87a84c5621faf0>
+
+[#9]: /../../issues/9
+[#10]: /../../pull/10
 
 
 
@@ -653,6 +660,7 @@ All user visible changes to this project will be documented in this file. This p
 
 
 [`libspf2`]: https://www.libspf2.org
+[`msmtp`]: https://marlam.de/msmtp
 [Alpine Linux]: https://www.alpinelinux.org
 [Debian Linux]: https://www.debian.org
 [OpenDMARC]: https://github.com/trusteddomainproject/OpenDMARC

--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -22,14 +22,12 @@ RUN apk update \
  && apk upgrade \
  && apk add --no-cache \
         ca-certificates \
-        msmtp \
 <? } else { ?>
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends --no-install-suggests \
             inetutils-syslogd \
             ca-certificates \
-            msmtp-mta \
 <? } ?>
  && update-ca-certificates \
     \
@@ -37,9 +35,11 @@ RUN apt-get update \
 <? if ($isAlpineImage) { ?>
  && apk add --no-cache \
         libmilter libspf2 \
+        msmtp \
 <? } else { ?>
  && apt-get install -y --no-install-recommends --no-install-suggests \
             libmilter1.0.1 libspf2-2 \
+            msmtp-mta \
 <? } ?>
     \
  # Install tools for building

--- a/Dockerfile.tmpl.php
+++ b/Dockerfile.tmpl.php
@@ -22,12 +22,14 @@ RUN apk update \
  && apk upgrade \
  && apk add --no-cache \
         ca-certificates \
+        msmtp \
 <? } else { ?>
 RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends --no-install-suggests \
             inetutils-syslogd \
             ca-certificates \
+            msmtp-mta \
 <? } ?>
  && update-ca-certificates \
     \

--- a/README.md
+++ b/README.md
@@ -79,10 +79,9 @@ docker run --rm instrumentisto/opendmarc cat /etc/opendmarc/opendmarc.conf
 
 #### Sending reports
 
-The Docker images come with msmtp MTA preinstalled which you can use to send reports when requested via the `ruf` tag inside a DMARC record.
-For this to happen, in `opendmarc.conf` set `FailureReports true` and `FailureReportsSentBy` to your (probably noreply) sender address.
-Then, map an `/etc/msmtprc` configuration file that looks like this:
+This image comes with [`msmtp` MTA][30] preinstalled, which can be used to send reports when requested via the [`ruf` tag inside a DMARC record][32].
 
+For this to happen, in `opendmarc.conf` set `FailureReports true` and `FailureReportsSentBy` to your (probably `noreply`) sender address. Then, put an `/etc/msmtprc` configuration file that looks like this:
 ```
 defaults
 logfile -
@@ -93,10 +92,11 @@ port <SMTP port>
 from <sender address>
 ```
 
-Apart from substituting your MTA hostname/port and your sender address (again), consider adding TLS and authentication if you're
-touching untrusted network. See the msmtp man page for details.
+Apart from substituting your MTA hostname/port and your sender address (again), consider adding TLS and authentication if you're touching untrusted network. See the [`msmtp` man page][31] for details.
 
-Make sure to avoid mail loops, which can happen if processing your report mails violate your own DMARC rules, causing more reports.
+Make sure to avoid mail loops, which can happen if processing a report mails violates its own [DMARC][11] rules, causing more reports.
+
+
 
 
 ## Important tips
@@ -187,6 +187,9 @@ If you have any problems with or questions about this image, please contact us t
 [20]: http://skarnet.org/software/s6/overview.html
 [21]: https://github.com/just-containers/s6-overlay
 [22]: https://github.com/just-containers/s6-overlay#usage
+[30]: https://marlam.de/msmtp
+[31]: https://marlam.de/msmtp/msmtp.html
+[32]: https://dmarc.org/overview#odd_row
 [90]: https://github.com/instrumentisto/opendmarc-docker-image
 [91]: https://github.com/instrumentisto/opendmarc-docker-image/blob/main/LICENSE.md
 [92]: https://sourceforge.net/p/opendmarc/code/ci/master/tree/LICENSE

--- a/README.md
+++ b/README.md
@@ -77,7 +77,26 @@ To see default OpenDMARC configuration of this Docker image just run:
 docker run --rm instrumentisto/opendmarc cat /etc/opendmarc/opendmarc.conf
 ```
 
+#### Sending reports
 
+The Docker images come with msmtp MTA preinstalled which you can use to send reports when requested via the `ruf` tag inside a DMARC record.
+For this to happen, in `opendmarc.conf` set `FailureReports true` and `FailureReportsSentBy` to your (probably noreply) sender address.
+Then, map an `/etc/msmtprc` configuration file that looks like this:
+
+```
+defaults
+logfile -
+
+account default
+host <SMTP host>
+port <SMTP port>
+from <sender address>
+```
+
+Apart from substituting your MTA hostname/port and your sender address (again), consider adding TLS and authentication if you're
+touching untrusted network. See the msmtp man page for details.
+
+Make sure to avoid mail loops, which can happen if processing your report mails violate your own DMARC rules, causing more reports.
 
 
 ## Important tips

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,12 +12,12 @@ RUN apk update \
  && apk upgrade \
  && apk add --no-cache \
         ca-certificates \
-        msmtp \
  && update-ca-certificates \
     \
  # Install OpenDMARC dependencies
  && apk add --no-cache \
         libmilter libspf2 \
+        msmtp \
     \
  # Install tools for building
  && apk add --no-cache --virtual .tool-deps \

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -12,6 +12,7 @@ RUN apk update \
  && apk upgrade \
  && apk add --no-cache \
         ca-certificates \
+        msmtp \
  && update-ca-certificates \
     \
  # Install OpenDMARC dependencies

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends --no-install-suggests \
             inetutils-syslogd \
             ca-certificates \
+            msmtp-mta \
  && update-ca-certificates \
     \
  # Install OpenDMARC dependencies

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -13,12 +13,12 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends --no-install-suggests \
             inetutils-syslogd \
             ca-certificates \
-            msmtp-mta \
  && update-ca-certificates \
     \
  # Install OpenDMARC dependencies
  && apt-get install -y --no-install-recommends --no-install-suggests \
             libmilter1.0.1 libspf2-2 \
+            msmtp-mta \
     \
  # Install tools for building
  && toolDeps=" \

--- a/tests/main.bats
+++ b/tests/main.bats
@@ -73,8 +73,15 @@
   [ "$status" -eq 0 ]
 }
 
-@test "sendmail: exists" {
+
+@test "sendmail: is present" {
   run docker run --rm --pull never --entrypoint sh $IMAGE -c \
-    "test -f /usr/sbin/sendmail"
+    'which sendmail'
+  [ "$status" -eq 0 ]
+}
+
+@test "sendmail: runs ok" {
+  run docker run --rm --pull never --entrypoint sh $IMAGE -c \
+    'sendmail --help'
   [ "$status" -eq 0 ]
 }

--- a/tests/main.bats
+++ b/tests/main.bats
@@ -72,3 +72,9 @@
     '/sbin/syslogd --help'
   [ "$status" -eq 0 ]
 }
+
+@test "sendmail: exists" {
+  run docker run --rm --pull never --entrypoint sh $IMAGE -c \
+    "test -f /usr/sbin/sendmail"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
This implements `/usr/sbin/sendmail` which is needed by `FailureReports true`.

Also adds a new section about sending reports to the README.md.

Note that "aggregate reports" are outside the scope of my testing and this PR. `FailureReports true` generates reports immediately for individual emails.

I sadly didn't find a way around specifying the from address a second time in `/etc/msmtprc`, even though it's already known via `FailureReportsSentBy` OpenDMARC configuration option.

Resolves #9 